### PR TITLE
Label terminating pods

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/react-router": "^4.0.27",
     "@types/react-router-dom": "^4.2.3",
     "@types/superagent": "^3.5.7",
-    "argo-ui": "^2.1.1-alpha7",
+    "argo-ui": "^2.1.1-alpha8",
     "awesome-typescript-loader": "^3.4.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.3",

--- a/src/app/applications/components/utils.tsx
+++ b/src/app/applications/components/utils.tsx
@@ -168,10 +168,10 @@ export function getPodStateReason(pod: appModels.State): { message: string; reas
         }
     }
 
-    if ((pod as any).deletionTimestamp && pod.status.reason === 'NodeLost') {
+    if ((pod as any).metadata.deletionTimestamp && pod.status.reason === 'NodeLost') {
         reason = 'Unknown';
         message = '';
-    } else if ((pod as any).deletionTimestamp) {
+    } else if ((pod as any).metadata.deletionTimestamp) {
         reason = 'Terminating';
         message = '';
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,9 +184,9 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-argo-ui@^2.1.1-alpha7:
-  version "2.1.1-alpha7"
-  resolved "https://registry.yarnpkg.com/argo-ui/-/argo-ui-2.1.1-alpha7.tgz#d3bacb30e5bbce99805d6be935a4439bbb280f20"
+argo-ui@^2.1.1-alpha8:
+  version "2.1.1-alpha8"
+  resolved "https://registry.yarnpkg.com/argo-ui/-/argo-ui-2.1.1-alpha8.tgz#b22a8fb43147203e458d4c057cb93a6b6d20ccb1"
   dependencies:
     aws-sdk "^2.188.0"
     body-parser "^1.18.2"


### PR DESCRIPTION
Look in a different place for `deletionTimestamp` so that we can show the `terminating` label on pods that are terminating.  Closes https://github.com/argoproj/argo-cd/issues/336.