### PR TITLE
Label apps with overrides

### DIFF
--- a/src/app/applications/components/application-details/application-details.tsx
+++ b/src/app/applications/components/application-details/application-details.tsx
@@ -357,16 +357,21 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{ na
     private getResourceLabels(resource: appModels.ResourceNode | appModels.ResourceState): string[] {
         const labels: string[] = [];
         const {resourceNode} = AppUtils.getStateAndNode(resource);
-        if (resourceNode.state.kind === 'Pod') {
-            const {reason}  = AppUtils.getPodStateReason(resourceNode.state);
-            if (reason) {
-                labels.push(reason);
-            }
+        switch(resourceNode.state.kind) {
+            case 'Pod':
+                const {reason}  = AppUtils.getPodStateReason(resourceNode.state);
+                if (reason) {
+                    labels.push(reason);
+                }
 
-            const allStatuses = resourceNode.state.status.containerStatuses;
-            const readyStatuses = allStatuses.filter((s: ContainerStatus) => ('running' in s.state));
-            const readyContainers = '' + readyStatuses.length + '/' + allStatuses.length + ' containers ready';
-            labels.push(readyContainers);
+                const allStatuses = resourceNode.state.status.containerStatuses;
+                const readyStatuses = allStatuses.filter((s: ContainerStatus) => ('running' in s.state));
+                const readyContainers = '' + readyStatuses.length + '/' + allStatuses.length + ' containers ready';
+                labels.push(readyContainers);
+                break;
+
+            case 'Application':
+                break;
         }
         return labels;
     }

--- a/src/app/applications/components/application-details/application-details.tsx
+++ b/src/app/applications/components/application-details/application-details.tsx
@@ -371,6 +371,9 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{ na
                 break;
 
             case 'Application':
+                const appSrc = resourceNode.state.spec.source;
+                const countOfOverrides = 'componentParameterOverrides' in appSrc && appSrc.componentParameterOverrides.length || 0;
+                labels.push('' + countOfOverrides + ' parameter override(s)');
                 break;
         }
         return labels;

--- a/src/app/applications/components/application-details/application-details.tsx
+++ b/src/app/applications/components/application-details/application-details.tsx
@@ -357,7 +357,7 @@ export class ApplicationDetails extends React.Component<RouteComponentProps<{ na
     private getResourceLabels(resource: appModels.ResourceNode | appModels.ResourceState): string[] {
         const labels: string[] = [];
         const {resourceNode} = AppUtils.getStateAndNode(resource);
-        switch(resourceNode.state.kind) {
+        switch (resourceNode.state.kind) {
             case 'Pod':
                 const {reason}  = AppUtils.getPodStateReason(resourceNode.state);
                 if (reason) {


### PR DESCRIPTION
Closes https://github.com/argoproj/argo-cd/issues/503 by adding a label to show how many overrides are on a given app.  Here's one where Guestbook has been added as follows:

```
./dist/argocd app create --name guestbook-default --repo https://github.com/argoproj/argocd-example-apps.git --path guestbook --env default --dest-server https://`minikube ip`:8443 -p guestbook=image=example/guestbook:latest
```

![image](https://user-images.githubusercontent.com/1137108/45233558-f8d77900-b287-11e8-96d6-69d8424c81ea.png)
