### PR TITLE
Allow 'syncApplication' action to reference target revision rather th…

### DIFF
--- a/src/app/applications/components/applications-list/applications-list.tsx
+++ b/src/app/applications/components/applications-list/applications-list.tsx
@@ -158,7 +158,7 @@ export class ApplicationsList extends React.Component<Props, State> {
                                                             <DropDownMenu anchor={() =>
                                                                 <button className='argo-button argo-button--base-o'>Actions  <i className='fa fa-caret-down'/></button>
                                                             } items={[
-                                                                { title: 'Sync', action: () => this.syncApplication(app.metadata.name, 'HEAD') },
+                                                                { title: 'Sync', action: () => this.syncApplication(app.metadata.name, app.spec.source.targetRevision || 'HEAD') },
                                                                 { title: 'Delete', action: () => this.deleteApplication(app.metadata.name) },
                                                             ]} />
                                                         </div>


### PR DESCRIPTION
…en hard-coding to 'HEAD''

Currently the application action 'Sync' is hard-coded to 'HEAD'. This change allows 'Sync' to reference the targetRevision if it has been provided.

The main concern is that it is not intuitive or known to the user that they are syncing to HEAD even though a target revision has been explicitly provided. Not ideal for pinning prod down to a specific revision